### PR TITLE
add new config API for use with SDK 5.14.0+, similar to 6.0

### DIFF
--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.6.4" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.14.0-alpha.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/src/LaunchDarkly.ServerSdk.Redis.StrongName/LaunchDarkly.ServerSdk.Redis.StrongName.csproj
+++ b/src/LaunchDarkly.ServerSdk.Redis.StrongName/LaunchDarkly.ServerSdk.Redis.StrongName.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.6.4" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.14.0-alpha.1" />
     <PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.6" />
   </ItemGroup>
 

--- a/src/LaunchDarkly.ServerSdk.Redis.StrongName/LaunchDarkly.ServerSdk.Redis.StrongName.csproj
+++ b/src/LaunchDarkly.ServerSdk.Redis.StrongName/LaunchDarkly.ServerSdk.Redis.StrongName.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.1.1</Version>
+    <Version>1.2.0-alpha.1</Version>
     <TargetFrameworks>netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <PackageLicenseUrl>https://raw.githubusercontent.com/launchdarkly/dotnet-server-sdk-redis/master/LICENSE</PackageLicenseUrl>
     <AssemblyName>LaunchDarkly.ServerSdk.Redis.StrongName</AssemblyName>
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <Compile Include="..\LaunchDarkly.ServerSdk.Redis\*.cs" Exclude="..\LaunchDarkly.ServerSdk.Redis\AssemblyInfo.cs" />
+    <Compile Include="..\LaunchDarkly.ServerSdk.Redis\Integrations\*.cs" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/src/LaunchDarkly.ServerSdk.Redis/Integrations/Redis.cs
+++ b/src/LaunchDarkly.ServerSdk.Redis/Integrations/Redis.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Net;
+using LaunchDarkly.Client.Interfaces;
+
+namespace LaunchDarkly.Client.Integrations
+{
+    /// <summary>
+    /// Integration between the LaunchDarkly SDK and Redis.
+    /// </summary>
+    public static class Redis
+    {
+        /// <summary>
+        /// The default location of the Redis server: <c>localhost:6379</c>
+        /// </summary>
+        public static readonly EndPoint DefaultRedisEndPoint = new DnsEndPoint("localhost", 6379);
+
+        /// <summary>
+        /// The default value for <see cref="RedisDataStoreBuilder.Prefix"/>.
+        /// </summary>
+        public static readonly string DefaultPrefix = "launchdarkly";
+
+        /// <summary>
+        /// The default value for <see cref="RedisDataStoreBuilder.ConnectTimeout(TimeSpan)"/>.
+        /// </summary>
+        public static readonly TimeSpan DefaultConnectTimeout = TimeSpan.FromSeconds(5);
+
+        /// <summary>
+        /// The default value for <see cref="RedisDataStoreBuilder.ResponseTimeout(TimeSpan)"/>.
+        /// </summary>
+        public static readonly TimeSpan DefaultResponseTimeout = TimeSpan.FromSeconds(3);
+
+        /// <summary>
+        /// The default value for <see cref="RedisDataStoreBuilder.OperationTimeout(TimeSpan)"/>.
+        /// </summary>
+        public static readonly TimeSpan DefaultOperationTimeout = TimeSpan.FromSeconds(3);
+
+        /// <summary>
+        /// Returns a builder object for creating a Redis-backed data store.
+        /// </summary>
+        /// <remarks>
+        /// This object can be modified with <see cref="RedisDataStoreBuilder"/> methods for any desired
+        /// custom Redis options. Then, pass it to <see cref="Components.PersistentDataStore(IPersistentDataStoreFactory)"/>
+        /// and set any desired caching options. Finally, pass the result to <see cref="ConfigurationBuilder.DataStore(IDataStoreFactory)"/>.
+        /// </remarks>
+        /// <example>
+        /// <code>
+        ///     var config = Configuration.Builder("sdk-key")
+        ///         .DataStore(
+        ///             Components.PersistentDataStore(
+        ///                 Redis.DataStore().Url("redis://my-redis-host")
+        ///             ).CacheSeconds(15)
+        ///         )
+        ///         .Build();
+        /// </code>
+        /// </example>
+        /// <returns>a data store configuration object</returns>
+        public static RedisDataStoreBuilder DataStore() => new RedisDataStoreBuilder();
+    }
+}

--- a/src/LaunchDarkly.ServerSdk.Redis/Integrations/Redis.cs
+++ b/src/LaunchDarkly.ServerSdk.Redis/Integrations/Redis.cs
@@ -40,7 +40,7 @@ namespace LaunchDarkly.Client.Integrations
         /// <remarks>
         /// This object can be modified with <see cref="RedisDataStoreBuilder"/> methods for any desired
         /// custom Redis options. Then, pass it to <see cref="Components.PersistentDataStore(IPersistentDataStoreFactory)"/>
-        /// and set any desired caching options. Finally, pass the result to <see cref="ConfigurationBuilder.DataStore(IDataStoreFactory)"/>.
+        /// and set any desired caching options. Finally, pass the result to <see cref="IConfigurationBuilder.DataStore(IFeatureStoreFactory)"/>.
         /// </remarks>
         /// <example>
         /// <code>

--- a/src/LaunchDarkly.ServerSdk.Redis/Integrations/RedisDataStoreBuilder.cs
+++ b/src/LaunchDarkly.ServerSdk.Redis/Integrations/RedisDataStoreBuilder.cs
@@ -16,8 +16,8 @@ namespace LaunchDarkly.Client.Integrations
     /// Obtain an instance of this class by calling <see cref="Redis.DataStore"/>. After calling its methods
     /// to specify any desired custom settings, wrap it in a <see cref="PersistentDataStoreBuilder"/>
     /// by calling <see cref="Components.PersistentDataStore(IPersistentDataStoreFactory)"/>, then pass
-    /// the result into the SDK configuration with <see cref="ConfigurationBuilder.DataStore(IDataStoreFactory)"/>.
-    /// You do not need to call <see cref="CreatePersistentDataStore(LdClientContext)"/> yourself to build
+    /// the result into the SDK configuration with <see cref="IConfigurationBuilder.DataStore(IFeatureStoreFactory)"/>.
+    /// You do not need to call <see cref="CreatePersistentDataStore()"/> yourself to build
     /// the actual data store; that will be done by the SDK.
     /// </para>
     /// <para>
@@ -222,6 +222,6 @@ namespace LaunchDarkly.Client.Integrations
 
         /// <inheritdoc/>
         public IFeatureStoreCore CreatePersistentDataStore() =>
-            new LaunchDarkly.Client.Redis.RedisFeatureStoreCore(_redisConfig, _prefix, null)
+            new LaunchDarkly.Client.Redis.RedisFeatureStoreCore(_redisConfig, _prefix, null);
     }
 }

--- a/src/LaunchDarkly.ServerSdk.Redis/Integrations/RedisDataStoreBuilder.cs
+++ b/src/LaunchDarkly.ServerSdk.Redis/Integrations/RedisDataStoreBuilder.cs
@@ -1,0 +1,227 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using LaunchDarkly.Client.Interfaces;
+using LaunchDarkly.Client.Utils;
+using StackExchange.Redis;
+
+namespace LaunchDarkly.Client.Integrations
+{
+    /// <summary>
+    /// A <a href="http://en.wikipedia.org/wiki/Builder_pattern">builder</a> for configuring the
+    /// Redis-based persistent data store.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Obtain an instance of this class by calling <see cref="Redis.DataStore"/>. After calling its methods
+    /// to specify any desired custom settings, wrap it in a <see cref="PersistentDataStoreBuilder"/>
+    /// by calling <see cref="Components.PersistentDataStore(IPersistentDataStoreFactory)"/>, then pass
+    /// the result into the SDK configuration with <see cref="ConfigurationBuilder.DataStore(IDataStoreFactory)"/>.
+    /// You do not need to call <see cref="CreatePersistentDataStore(LdClientContext)"/> yourself to build
+    /// the actual data store; that will be done by the SDK.
+    /// </para>
+    /// <para>
+    /// Builder calls can be chained, for example:
+    /// </para>
+    /// <code>
+    ///     var config = Configuration.Builder("sdk-key")
+    ///         .DataStore(
+    ///             Components.PersistentDataStore(
+    ///                 Redis.DataStore()
+    ///                     .Uri(new Uri("redis://my-redis-host"))
+    ///                     .Database(1)
+    ///                 )
+    ///                 .CacheSeconds(15)
+    ///             )
+    ///         .Build();
+    /// </code>
+    /// </remarks>
+    public sealed class RedisDataStoreBuilder : IPersistentDataStoreFactory
+    {
+        internal ConfigurationOptions _redisConfig = new ConfigurationOptions();
+        internal string _prefix = Redis.DefaultPrefix;
+
+        internal RedisDataStoreBuilder()
+        {
+            _redisConfig.EndPoints.Add(Redis.DefaultRedisEndPoint);
+            _redisConfig.ConnectTimeout = (int)Redis.DefaultConnectTimeout.TotalMilliseconds;
+            _redisConfig.ResponseTimeout = (int)Redis.DefaultResponseTimeout.TotalMilliseconds;
+        }
+
+        /// <summary>
+        /// Specifies all Redis configuration options at once.
+        /// </summary>
+        /// <param name="config">a <see cref="ConfigurationOptions"/> instance</param>
+        /// <returns>the builder</returns>
+        public RedisDataStoreBuilder RedisConfiguration(ConfigurationOptions config)
+        {
+            _redisConfig = config.Clone();
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies a single Redis server by hostname and port.
+        /// </summary>
+        /// <param name="host">hostname of the Redis server</param>
+        /// <param name="port">port of the Redis server</param>
+        /// <returns>the builder</returns>
+        public RedisDataStoreBuilder HostAndPort(string host, int port) =>
+            EndPoint(new DnsEndPoint(host, port));
+
+        /// <summary>
+        /// Specifies a single Redis server as an EndPoint.
+        /// </summary>
+        /// <param name="endPoint">location of the Redis server</param>
+        /// <returns>the builder</returns>
+        public RedisDataStoreBuilder EndPoint(EndPoint endPoint) =>
+            EndPoints(new List<EndPoint> { endPoint });
+
+        /// <summary>
+        /// Shortcut for calling <see cref="Uri(System.Uri)"/> with a string.
+        /// </summary>
+        /// <param name="uri">the Redis server URI as a string</param>
+        /// <returns>the builder</returns>
+        /// <seealso cref="Uri(System.Uri)"/>
+        public RedisDataStoreBuilder Uri(string uri) => Uri(new Uri(uri));
+
+        /// <summary>
+        /// Specifies a Redis server - and, optionally, other properties including
+        /// credentials and database number - using a URI.
+        /// </summary>
+        /// <param name="uri">the Redis server URI</param>
+        /// <returns>the builder</returns>
+        /// <seealso cref="Uri(string)"/>
+        public RedisDataStoreBuilder Uri(Uri uri)
+        {
+            if (uri.Scheme.ToLower() != "redis")
+            {
+                throw new ArgumentException("URI scheme must be 'redis'");
+            }
+            HostAndPort(uri.Host, uri.Port);
+            if (!string.IsNullOrEmpty(uri.UserInfo))
+            {
+                var parts = uri.UserInfo.Split(':');
+                if (parts.Length == 2)
+                {
+                    // Redis doesn't use the username
+                    _redisConfig.Password = parts[1];
+                }
+                else
+                {
+                    throw new ArgumentException("Credentials must be in the format ':password'");
+                }
+            }
+            if (!string.IsNullOrEmpty(uri.AbsolutePath) && uri.AbsolutePath != "/")
+            {
+                var path = uri.AbsolutePath;
+                if (path.StartsWith("/"))
+                {
+                    path = path.Substring(1);
+                }
+                var dbIndex = Int32.Parse(path);
+                _redisConfig.DefaultDatabase = dbIndex;
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies multiple Redis servers as a list of EndPoints.
+        /// </summary>
+        /// <param name="endPoints">locations of the Redis servers</param>
+        /// <returns>the builder</returns>
+        public RedisDataStoreBuilder EndPoints(IList<EndPoint> endPoints)
+        {
+            _redisConfig.EndPoints.Clear();
+            foreach (var ep in endPoints)
+            {
+                _redisConfig.EndPoints.Add(ep);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies which database to use within the Redis server. The default is 0.
+        /// </summary>
+        /// <param name="database">index of the database to use</param>
+        /// <returns>the builder</returns>
+        public RedisDataStoreBuilder DatabaseIndex(int database)
+        {
+            _redisConfig.DefaultDatabase = database;
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies the maximum time to wait for a connection to the Redis server.
+        /// </summary>
+        /// <param name="timeout">the timeout interval</param>
+        /// <returns>the builder</returns>
+        public RedisDataStoreBuilder ConnectTimeout(TimeSpan timeout)
+        {
+            _redisConfig.ConnectTimeout = (int)timeout.TotalMilliseconds;
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies the maximum time to wait for data on the Redis connection.
+        /// </summary>
+        /// <param name="timeout">the timeout interval</param>
+        /// <returns>the builder</returns>
+        /// <seealso cref="OperationTimeout(TimeSpan)"/>
+        public RedisDataStoreBuilder ResponseTimeout(TimeSpan timeout)
+        {
+            _redisConfig.ResponseTimeout = (int)timeout.TotalMilliseconds;
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies the maximum time to wait for each synchronous Redis operation to complete.
+        /// If you are seeing timeout errors - which could result from either an overburdened
+        /// Redis server, or an unusually large operation such as storing a very large feature
+        /// flag - you may want to increase this setting.
+        /// </summary>
+        /// <param name="timeout">the timeout interval</param>
+        /// <returns>the builder</returns>
+        /// <seealso cref="ResponseTimeout(TimeSpan)"/>
+        public RedisDataStoreBuilder OperationTimeout(TimeSpan timeout)
+        {
+            _redisConfig.SyncTimeout = (int)timeout.TotalMilliseconds;
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies the namespace prefix for all keys stored in Redis.
+        /// </summary>
+        /// <param name="prefix">the namespace prefix, or null to use <see cref="Redis.DefaultPrefix"/></param>
+        /// <returns>the builder</returns>
+        public RedisDataStoreBuilder Prefix(string prefix)
+        {
+            _prefix = string.IsNullOrEmpty(prefix) ? Redis.DefaultPrefix : prefix;
+            return this;
+        }
+
+        /// <summary>
+        /// Allows you to modify any of the configuration options supported by StackExchange.Redis
+        /// directly. The current configuration will be passed to your Action, which can modify it
+        /// in any way.
+        /// </summary>
+        /// <example>
+        /// <code>
+        ///     Redis.DataStore()
+        ///         .RedisConfigChanges((config) => {
+        ///             config.Ssl = true;
+        ///         })
+        /// </code>
+        /// </example>
+        /// <param name="modifyConfig"></param>
+        /// <returns></returns>
+        public RedisDataStoreBuilder RedisConfigChanges(Action<ConfigurationOptions> modifyConfig)
+        {
+            modifyConfig.Invoke(_redisConfig);
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public IFeatureStoreCore CreatePersistentDataStore() =>
+            new LaunchDarkly.Client.Redis.RedisFeatureStoreCore(_redisConfig, _prefix, null)
+    }
+}

--- a/src/LaunchDarkly.ServerSdk.Redis/LaunchDarkly.ServerSdk.Redis.csproj
+++ b/src/LaunchDarkly.ServerSdk.Redis/LaunchDarkly.ServerSdk.Redis.csproj
@@ -13,10 +13,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.6.4" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.14.0-alpha.1" />
     <PackageReference Include="StackExchange.Redis" Version="1.2.6" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Integrations\" />
+  </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <DocumentationFile>bin\Debug\netstandard2.0\LaunchDarkly.ServerSdk.Redis.xml</DocumentationFile>
   </PropertyGroup>

--- a/src/LaunchDarkly.ServerSdk.Redis/LaunchDarkly.ServerSdk.Redis.csproj
+++ b/src/LaunchDarkly.ServerSdk.Redis/LaunchDarkly.ServerSdk.Redis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.1.1</Version>
+    <Version>1.2.0-alpha.1</Version>
     <TargetFrameworks>netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <PackageLicenseUrl>https://raw.githubusercontent.com/launchdarkly/dotnet-server-sdk-redis/master/LICENSE</PackageLicenseUrl>
     <AssemblyName>LaunchDarkly.ServerSdk.Redis</AssemblyName>

--- a/src/LaunchDarkly.ServerSdk.Redis/RedisComponents.cs
+++ b/src/LaunchDarkly.ServerSdk.Redis/RedisComponents.cs
@@ -4,9 +4,17 @@ using System.Net;
 namespace LaunchDarkly.Client.Redis
 {
     /// <summary>
-    /// Contains the factory method for building a Redis implementation of <see cref="IFeatureStore"/>,
-    /// as well as default values for the store's properties.
+    /// Obsolete entry point for the Redis integration.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This class is retained in version 1.2 of the library for backward compatibility. For the new
+    /// preferred way to configure the Redis integration, see <see cref="LaunchDarkly.Client.Integrations.Redis"/>.
+    /// Updating to the latter now will make it easier to adopt version 6.0 of the LaunchDarkly .NET SDK, since
+    /// an identical API is used there (except for the base namespace).
+    /// </para>
+    /// </remarks>
+    [Obsolete("Use LaunchDarkly.Client.Integrations.Redis")]
     public abstract class RedisComponents
     {
         /// <summary>

--- a/src/LaunchDarkly.ServerSdk.Redis/RedisFeatureStore.cs
+++ b/src/LaunchDarkly.ServerSdk.Redis/RedisFeatureStore.cs
@@ -17,15 +17,19 @@ namespace LaunchDarkly.Client.Redis
         // This is used for unit testing only
         private Action _updateHook;
 
-        internal RedisFeatureStoreCore(RedisFeatureStoreBuilder builder)
+        internal RedisFeatureStoreCore(
+            ConfigurationOptions redisConfig,
+            string prefix,
+            Action updateHook
+            )
         {
-            var redisConfig = builder.RedisConfig.Clone();
+            redisConfig = redisConfig.Clone();
             Log.InfoFormat("Creating Redis feature store using Redis server(s) at [{0}]",
                 String.Join(", ", redisConfig.EndPoints));
             _redis = ConnectionMultiplexer.Connect(redisConfig);
 
-            _prefix = builder.Prefix;
-            _updateHook = builder.UpdateHook;
+            _prefix = prefix;
+            _updateHook = updateHook;
         }
         
         public bool InitializedInternal()

--- a/src/LaunchDarkly.ServerSdk.Redis/RedisFeatureStoreBuilder.cs
+++ b/src/LaunchDarkly.ServerSdk.Redis/RedisFeatureStoreBuilder.cs
@@ -7,7 +7,7 @@ using StackExchange.Redis;
 namespace LaunchDarkly.Client.Redis
 {
     /// <summary>
-    /// Obsolete builder for a the Redis data store.
+    /// Obsolete builder for the Redis data store.
     /// </summary>
     /// <remarks>
     /// <para>

--- a/src/LaunchDarkly.ServerSdk.Redis/RedisFeatureStoreBuilder.cs
+++ b/src/LaunchDarkly.ServerSdk.Redis/RedisFeatureStoreBuilder.cs
@@ -9,6 +9,7 @@ namespace LaunchDarkly.Client.Redis
     /// <summary>
     /// Obsolete builder for a the Redis data store.
     /// </summary>
+    /// <remarks>
     /// <para>
     /// This class is retained in version 1.2 of the library for backward compatibility. For the new
     /// preferred way to configure the Redis integration, see <see cref="LaunchDarkly.Client.Integrations.Redis"/>.

--- a/src/LaunchDarkly.ServerSdk.Redis/RedisFeatureStoreBuilder.cs
+++ b/src/LaunchDarkly.ServerSdk.Redis/RedisFeatureStoreBuilder.cs
@@ -7,11 +7,16 @@ using StackExchange.Redis;
 namespace LaunchDarkly.Client.Redis
 {
     /// <summary>
-    /// Builder for a Redis-based implementation of <see cref="IFeatureStore"/>.
-    /// Create an instance of the builder by calling <see cref="RedisComponents.RedisFeatureStore"/>;
-    /// configure it using the setter methods; then pass the builder to
-    /// <see cref="ConfigurationExtensions.WithFeatureStore(Configuration, IFeatureStore)"/>.
+    /// Obsolete builder for a the Redis data store.
     /// </summary>
+    /// <para>
+    /// This class is retained in version 1.2 of the library for backward compatibility. For the new
+    /// preferred way to configure the Redis integration, see <see cref="LaunchDarkly.Client.Integrations.Redis"/>.
+    /// Updating to the latter now will make it easier to adopt version 6.0 of the LaunchDarkly .NET SDK, since
+    /// an identical API is used there (except for the base namespace).
+    /// </para>
+    /// </remarks>
+    [Obsolete("Use LaunchDarkly.Client.Integrations.Redis")]
     public sealed class RedisFeatureStoreBuilder : IFeatureStoreFactory
     {
         internal ConfigurationOptions RedisConfig { get; private set; } = new ConfigurationOptions();
@@ -42,7 +47,7 @@ namespace LaunchDarkly.Client.Redis
         /// <returns>the feature store</returns>
         public IFeatureStore CreateFeatureStore()
         {
-            var core = new RedisFeatureStoreCore(this);
+            var core = new RedisFeatureStoreCore(RedisConfig, Prefix, UpdateHook);
             return CachingStoreWrapper.Builder(core).WithCaching(Caching).Build();
         }
         

--- a/test/LaunchDarkly.ServerSdk.Redis.Tests/LaunchDarkly.ServerSdk.Redis.Tests.csproj
+++ b/test/LaunchDarkly.ServerSdk.Redis.Tests/LaunchDarkly.ServerSdk.Redis.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.6.4" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.14.0-alpha.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />

--- a/test/LaunchDarkly.ServerSdk.Redis.Tests/RedisFeatureStoreBuilderTest.cs
+++ b/test/LaunchDarkly.ServerSdk.Redis.Tests/RedisFeatureStoreBuilderTest.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace LaunchDarkly.Client.Redis.Tests
 {
+#pragma warning disable 0618
     public class RedisFeatureStoreBuilderTest
     {
         [Fact]
@@ -103,4 +104,5 @@ namespace LaunchDarkly.Client.Redis.Tests
             Assert.Equal(8000, builder.RedisConfig.ResponseTimeout);
         }
     }
+#pragma warning restore 0618
 }

--- a/test/LaunchDarkly.ServerSdk.Redis.Tests/RedisFeatureStoreTest.cs
+++ b/test/LaunchDarkly.ServerSdk.Redis.Tests/RedisFeatureStoreTest.cs
@@ -8,14 +8,20 @@ namespace LaunchDarkly.Client.Redis.Tests
     {
         override protected IFeatureStore CreateStoreImpl(FeatureStoreCacheConfig caching)
         {
-            return RedisFeatureStoreBuilder.Default().WithCaching(caching).
-                CreateFeatureStore();
+            return Components.PersistentDataStore(
+                    Integrations.Redis.DataStore()
+                )
+                .CacheTime(caching.Ttl)
+                .CreateFeatureStore();
         }
 
         override protected IFeatureStore CreateStoreImplWithPrefix(string prefix)
         {
-            return RedisFeatureStoreBuilder.Default().WithPrefix(prefix)
-                .WithCaching(FeatureStoreCacheConfig.Disabled).CreateFeatureStore();
+            return Components.PersistentDataStore(
+                    Integrations.Redis.DataStore().Prefix(prefix)
+                )
+                .NoCaching()
+                .CreateFeatureStore();
         }
 
         protected override IFeatureStore CreateStoreImplWithUpdateHook(Action hook)


### PR DESCRIPTION
This is for the 1.2 release of `LaunchDarkly.ServerSdk.Redis`; the other PR is for the 2.0 release.

In 1.2, we're deprecating the old Redis config builder, and adding a new entry point and builder that look like the ones we'll be using in 2.0. This corresponds to the .SDK 5.14.0 release which will add configuration APIs that are basically the same as they'll be in 6.0. So, developers who update to this now will have minimal migration to do for SDK 6.0 (except for a search-and-replace to change the namespace from `LaunchDarkly.Client` to `LaunchDarkly.Sdk.Server`. This is basically the same as what we did for Java SDK 5.