### PR TITLE
add NuGet and GH Pages badges, change CI badge style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # LaunchDarkly Server-Side SDK for .NET - Redis integration
 
-[![CircleCI](https://circleci.com/gh/launchdarkly/dotnet-server-sdk-redis.svg?style=svg)](https://circleci.com/gh/launchdarkly/dotnet-server-sdk-redis)
+[![NuGet](https://img.shields.io/nuget/v/LaunchDarkly.ServerSdk.Redis.svg?style=flat-square)](https://www.nuget.org/packages/LaunchDarkly.ServerSdk.Redis/)
+[![CircleCI](https://circleci.com/gh/launchdarkly/dotnet-server-sdk-redis.svg?style=shield)](https://circleci.com/gh/launchdarkly/dotnet-server-sdk-redis)
+[![Documentation](https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8)](https://launchdarkly.github.io/dotnet-server-sdk-redis)
 
 This library provides a Redis-backed persistence mechanism (data store) for the [LaunchDarkly .NET SDK](https://github.com/launchdarkly/dotnet-server-sdk), replacing the default in-memory data store. The underlying Redis client implementation is [StackExchange.Redis](https://github.com/StackExchange/StackExchange.Redis).
 

--- a/src/LaunchDarkly.ServerSdk.Redis/LaunchDarkly.ServerSdk.Redis.csproj
+++ b/src/LaunchDarkly.ServerSdk.Redis/LaunchDarkly.ServerSdk.Redis.csproj
@@ -11,7 +11,7 @@
     <Owners>LaunchDarkly</Owners>
     <Description>LaunchDarkly Server-Side .NET SDK Redis Integration</Description>
     <Copyright>Copyright 2018 LaunchDarkly</Copyright>
-    <LicenseExpression>Apache-2.0</LicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/launchdarkly/dotnet-server-sdk-redis</PackageProjectUrl>
     <RepositoryUrl>https://github.com/launchdarkly/dotnet-server-sdk-redis</RepositoryUrl>
     <RepositoryBranch>master</RepositoryBranch>


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/35503443/106539510-ff976400-64b2-11eb-946c-07406ddbe84f.png)

After:

![image](https://user-images.githubusercontent.com/35503443/106539531-07ef9f00-64b3-11eb-8aaf-d4f7236c2c96.png)

(CircleCI offers two badge styles. I switched to the one that includes a label because, once there are multiple badges, it's unclear what "PASSED" by itself is supposed to mean. The lowercasing of "circleci" is not mine, it's how CircleCI renders the badge.)