### PR TITLE
update to use new docs structure + use latest prerelease SDK

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,11 @@ We encourage pull requests and other contributions from the community. Before su
  
 ### Prerequisites
 
-This project has multiple target frameworks as described in [`README.md`](./README.md). The .NET Framework target can be built only in a Windows environment; the others can be built either with or without a Windows environment. Download and install the latest .NET SDK tools first.
+To set up your SDK build time environment, you must [download .NET development tools and follow the instructions](https://dotnet.microsoft.com/download). .NET 5.0 is preferred, since the .NET 5.0 tools are able to build for all supported target platforms.
 
 The project has a package dependency on `StackExchange.Redis`. The dependency version is intended to be the _minimum_ compatible version; applications are expected to override this with their own dependency on some higher version.
 
-This project has two targets: .NET Standard 2.0 and .NET Framework 4.5.2. In Windows, you can build both; outside of Windows, you will need to [download .NET Core and follow the instructions](https://dotnet.microsoft.com/download) (make sure you have 2.0 or higher) and can only build the .NET Standard target.
+The unit test project uses code from the `dotnet-server-sdk-shared-tests` repository which is imported as a subtree. See the `README.md` file in that directory for more information.
 
 ### Building
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Version 3.0.0 and above of this library works with version 6.0.0 and above of th
 
 It has a dependency on StackExchange.Redis version 2.0.513. If you are using a higher version of StackExchange.Redis, you should install it explicitly as a dependency in your application to override this minimum version.
 
+For full usage details and examples, see the [API reference](launchdarkly.github.io/dotnet-server-sdk-redis).
+
 ## Supported .NET versions
 
 This version of the library is built for the following targets:
@@ -20,49 +22,6 @@ This version of the library is built for the following targets:
 * .NET Standard 2.0: works in .NET Core 2.x, .NET 5.x, or in a library targeted to .NET Standard 2.x or .NET 5.x.
 
 The .NET build tools should automatically load the most appropriate build of the library for whatever platform your application or library is targeted to.
-
-## Quick setup
-
-This assumes that you have already installed the LaunchDarkly .NET SDK.
-
-1. Use [NuGet](http://docs.nuget.org/docs/start-here/using-the-package-manager-console) to add this package to your project:
-
-        Install-Package LaunchDarkly.ServerSdk.Redis
-
-   (Previous versions of the library had two package names, because StackExchange.Redis had two different packages depending on whether you wanted strong-naming, but StackExchange.Redis 2.x no longer does this so there is only one LaunchDarkly.ServerSdk.Redis package now.)
-
-2. Import the package (note that the namespace is different from the package name):
-
-        using LaunchDarkly.Sdk.Server.Integrations;
-
-3. When configuring your `LdClient`, add the Redis data store as a `PersistentDataStore`. You may specify any custom Redis options using the methods of `RedisDataStoreBuilder`. For instance, to customize the Redis URI:
-
-```csharp
-        var ldConfig = Configuration.Default("YOUR_SDK_KEY")
-            .DataStore(
-                Components.PersistentDataStore(
-                    Redis.DataStore().Uri("redis://my-redis-host")
-                )
-            )
-            .Build();
-        var ldClient = new LdClient(ldConfig);
-```
-
-By default, the store will try to connect to a local Redis instance on port 6379.
-
-## Caching behavior
-
-The LaunchDarkly SDK has a standard caching mechanism for any persistent data store, to reduce database traffic. This is configured through the SDK's `PersistentDataStoreBuilder` class as described in the SDK documentation. For instance, to specify a cache TTL of 5 minutes:
-
-```csharp
-        var config = Configuration.Default("YOUR_SDK_KEY")
-            .DataStore(
-                Components.PersistentDataStore(
-                    Redis.DataStore().Uri("redis://my-redis-host")
-                ).CacheTime(TimeSpan.FromMinutes(5))
-            )
-            .Build();
-```
 
 ## Signing
 

--- a/docs-src/index.md
+++ b/docs-src/index.md
@@ -1,0 +1,50 @@
+The [`LaunchDarkly.ServerSdk.Redis`](https://nuget.org/packages/LaunchDarkly.ServerSdk.Redis) package provides a Redis-backed persistence mechanism (data store) for the [LaunchDarkly .NET SDK](https://github.com/launchdarkly/dotnet-server-sdk), replacing the default in-memory data store. The underlying Redis client implementation is [`StackExchange.Redis`](https://github.com/StackExchange/StackExchange.Redis).
+
+For more information, see also: [Using a persistent data store](https://docs.launchdarkly.com/v2.0/docs/using-a-persistent-feature-store).
+
+Version 3.0.0 and above of this library works with version 6.0.0 and above of the LaunchDarkly .NET SDK. For earlier versions of the SDK, use the latest 1.x release of this library.
+
+It has a dependency on `StackExchange.Redis` version 2.0.513. If you are using a higher version of `StackExchange.Redis`, you should install it explicitly as a dependency in your application to override this minimum version.
+
+The entry point for using this integration is the **<xref:LaunchDarkly.Sdk.Server.Integrations.Redis>** class in <xref:LaunchDarkly.Sdk.Server.Integrations>.
+
+## Quick setup
+
+This assumes that you have already installed the LaunchDarkly .NET SDK.
+
+1. Add the NuGet package [`LaunchDarkly.ServerSdk.Redis`](https://nuget.org/packages/LaunchDarkly.ServerSdk.Redis) to your project.
+
+   (Previous versions of the library had two package names, because StackExchange.Redis had two different packages depending on whether you wanted strong-naming, but StackExchange.Redis 2.x no longer does this so there is only one `LaunchDarkly.ServerSdk.Redis` package now.)
+
+2. Import the package (note that the namespace is different from the package name):
+
+        using LaunchDarkly.Sdk.Server.Integrations;
+
+3. When configuring your `LdClient`, add the Redis data store as a `PersistentDataStore`. You may specify any custom Redis options using the methods of `RedisDataStoreBuilder`. For instance, to customize the Redis URI:
+
+```csharp
+        var ldConfig = Configuration.Default("YOUR_SDK_KEY")
+            .DataStore(
+                Components.PersistentDataStore(
+                    Redis.DataStore().Uri("redis://my-redis-host")
+                )
+            )
+            .Build();
+        var ldClient = new LdClient(ldConfig);
+```
+
+By default, the store will try to connect to a local Redis instance on port 6379.
+
+## Caching behavior
+
+The LaunchDarkly SDK has a standard caching mechanism for any persistent data store, to reduce database traffic. This is configured through the SDK's `PersistentDataStoreBuilder` class as described in the SDK documentation. For instance, to specify a cache TTL of 5 minutes:
+
+```csharp
+        var config = Configuration.Default("YOUR_SDK_KEY")
+            .DataStore(
+                Components.PersistentDataStore(
+                    Redis.DataStore().Uri("redis://my-redis-host")
+                ).CacheTime(TimeSpan.FromMinutes(5))
+            )
+            .Build();
+```

--- a/docs-src/index.md
+++ b/docs-src/index.md
@@ -18,7 +18,9 @@ This assumes that you have already installed the LaunchDarkly .NET SDK.
 
 2. Import the package (note that the namespace is different from the package name):
 
+```csharp
         using LaunchDarkly.Sdk.Server.Integrations;
+```
 
 3. When configuring your `LdClient`, add the Redis data store as a `PersistentDataStore`. You may specify any custom Redis options using the methods of `RedisDataStoreBuilder`. For instance, to customize the Redis URI:
 

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="[6.0.0-alpha.9,]" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="[6.0.0-rc.1,]" />
     <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.0,]" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.ServerSdk" Version="[6.0.0-rc.1,]" />
-    <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.0,]" />
+    <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.1,]" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/src/LaunchDarkly.ServerSdk.Redis/LaunchDarkly.ServerSdk.Redis.csproj
+++ b/src/LaunchDarkly.ServerSdk.Redis/LaunchDarkly.ServerSdk.Redis.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-alpha.1</Version>
+    <Version>3.0.0-rc.1</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <AssemblyName>LaunchDarkly.ServerSdk.Redis</AssemblyName>
     <OutputType>Library</OutputType>
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="[6.0.0-alpha.9,]" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="[6.0.0-rc.1,]" />
     <PackageReference Include="StackExchange.Redis" Version="[2.0.513,]" />
   </ItemGroup>
 


### PR DESCRIPTION
This moves the main API doc content out of the obsolete `NamespaceDoc.cs` file into the new structure we use with DocFX, and generally improves some of the readme content. You can see a temporary build of the docs [here](https://174-140491920-gh.circle-artifacts.com/0/artifacts/index.html).