### PR TITLE
fix incorrect usage of special "initialized" key

### DIFF
--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -1,0 +1,24 @@
+publications:
+  - url: https://nuget.org/packages/LaunchDarkly.ServerSdk.Redis
+    description: NuGet
+
+releasableBranches:
+  - name: master
+    description: 2.x - for SDK 5.x + StackExchange.Redis 2.x
+  - name: 1.x
+    description: for SDK 5.x + StackExchange.Redis 1.x
+
+circleci:
+  windows:
+    context: org-global
+    env:
+      LD_RELEASE_DOCS_TARGET_FRAMEWORK: net45
+
+template:
+  name: dotnet-windows
+  skip:
+    - test  # tests require Redis - run them only in CI
+
+documentation:
+  title: LaunchDarkly SDK Redis Integration
+  githubPages: true

--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -20,5 +20,5 @@ template:
     - test  # tests require Redis - run them only in CI
 
 documentation:
-  title: LaunchDarkly SDK Redis Integration
+  title: LaunchDarkly .NET SDK Redis Integration
   githubPages: true

--- a/src/LaunchDarkly.ServerSdk.Redis/RedisFeatureStore.cs
+++ b/src/LaunchDarkly.ServerSdk.Redis/RedisFeatureStore.cs
@@ -13,6 +13,7 @@ namespace LaunchDarkly.Client.Redis
         
         private readonly ConnectionMultiplexer _redis;
         private readonly string _prefix;
+        private readonly string _initedKey;
         
         // This is used for unit testing only
         private Action _updateHook;
@@ -30,12 +31,13 @@ namespace LaunchDarkly.Client.Redis
 
             _prefix = prefix;
             _updateHook = updateHook;
+            _initedKey = prefix + ":$inited";
         }
         
         public bool InitializedInternal()
         {
             IDatabase db = _redis.GetDatabase();
-            return db.KeyExists(_prefix);
+            return db.KeyExists(_initedKey);
         }
 
         public void InitInternal(IDictionary<IVersionedDataKind, IDictionary<string, IVersionedData>> items)
@@ -54,7 +56,7 @@ namespace LaunchDarkly.Client.Redis
                     // transaction. We don't need to await them.
                 }
             }
-            txn.StringSetAsync(_prefix, "");
+            txn.StringSetAsync(_initedKey, "");
             txn.Execute();
         }
         


### PR DESCRIPTION
The standard for all of our SDK Redis integrations is that when a full data set has been written to the store, the Redis key `PREFIX:$inited` should be set (to any value), where `PREFIX` is the configured prefix (the `$` is a literal character, not part of a variable). That's how the SDK can detect if 1. it previously stored some data before restarting, so it can use the last known data if it doesn't yet have some from LD, or 2. the database has been populated by the Relay Proxy.

Unfortunately, all released versions of the Redis integration for the .NET SDK are doing this wrong: they are instead using just `PREFIX` as the key. This means that the SDK can detect if _it_ has populated the database, but not if _someone else_ has (like the Relay Proxy), and in the latter case it would behave as if no flag data were available.