### PR TITLE
updates for prerelease 7.0 SDK

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,13 +13,13 @@ workflows:
 jobs:
   test_dotnetcore:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:2.1-focal
+      - image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
       - image: redis
     steps:
       - checkout
       - run: dotnet restore
       - run: dotnet build src/LaunchDarkly.ServerSdk.Redis -f netstandard2.0
-      - run: dotnet test test/LaunchDarkly.ServerSdk.Redis.Tests -f netcoreapp2.1
+      - run: dotnet test test/LaunchDarkly.ServerSdk.Redis.Tests -f netcoreapp3.1
 
   test_dotnetframework:
     executor:
@@ -34,5 +34,5 @@ jobs:
           # not include improvements made in Redis after Redis 3.x, and it would not be
           # good to use it in production. But for our testing purposes here it's adequate.
       - run: dotnet restore
-      - run: dotnet build src/LaunchDarkly.ServerSdk.Redis -f net461
-      - run: dotnet test test/LaunchDarkly.ServerSdk.Redis.Tests -f net461
+      - run: dotnet build src/LaunchDarkly.ServerSdk.Redis -f net462
+      - run: dotnet test test/LaunchDarkly.ServerSdk.Redis.Tests -f net462

--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -6,6 +6,8 @@ publications:
 
 branches:
   - name: main
+    description: 4.x - for SDK 7+
+  - name: 3.x
     description: 3.x - for SDK 6+
   - name: 2.x
     description: for SDK 5.x + StackExchange.Redis 2.x
@@ -15,7 +17,7 @@ branches:
 jobs:
   - docker: {}
     template:
-      name: dotnet-linux
+      name: dotnet6-linux
       skip:
         - test  # tests require Redis - run them only in CI
     env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We encourage pull requests and other contributions from the community. Before su
  
 ### Prerequisites
 
-To set up your SDK build time environment, you must [download .NET development tools and follow the instructions](https://dotnet.microsoft.com/download). .NET 5.0 is preferred, since the .NET 5.0 tools are able to build for all supported target platforms.
+To set up your SDK build time environment, you must [download .NET development tools and follow the instructions](https://dotnet.microsoft.com/download). .NET 6.0 is preferred, since the .NET 6.0 tools are able to build for all supported target platforms.
 
 The project has a package dependency on `StackExchange.Redis`. The dependency version is intended to be the _minimum_ compatible version; applications are expected to override this with their own dependency on some higher version.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library provides a Redis-backed persistence mechanism (data store) for the 
 
 For more information, see also: [Using a persistent data store](https://docs.launchdarkly.com/v2.0/docs/using-a-persistent-feature-store).
 
-Version 3.0.0 and above of this library works with version 6.0.0 and above of the LaunchDarkly .NET SDK. For earlier versions of the SDK, use the latest 1.x release of this library.
+Version 4.0.0 and above of this library works with version 7.0.0 and above of the LaunchDarkly .NET SDK. For earlier versions of the SDK, see the changelog for which version of this library to use.
 
 It has a dependency on StackExchange.Redis version 2.0.513. If you are using a higher version of StackExchange.Redis, you should install it explicitly as a dependency in your application to override this minimum version.
 
@@ -18,8 +18,8 @@ For full usage details and examples, see the [API reference](launchdarkly.github
 
 This version of the library is built for the following targets:
 
-* .NET Framework 4.6.1: works in .NET Framework of that version or higher.
-* .NET Standard 2.0: works in .NET Core 2.x, .NET 5.x, or in a library targeted to .NET Standard 2.x or .NET 5.x.
+* .NET Framework 4.6.2: works in .NET Framework of that version or higher.
+* .NET Standard 2.0: works in .NET Core 3.x, .NET 6.x, or in a library targeted to .NET Standard 2.x.
 
 The .NET build tools should automatically load the most appropriate build of the library for whatever platform your application or library is targeted to.
 

--- a/dotnet-server-sdk-shared-tests/.circleci/config.yml
+++ b/dotnet-server-sdk-shared-tests/.circleci/config.yml
@@ -7,7 +7,7 @@ workflows:
 jobs:
   test:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:2.1-focal
+      - image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
     steps:
       - checkout
       - run: dotnet restore

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/BigSegmentStore/BigSegmentStoreBaseTestsTest.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/BigSegmentStore/BigSegmentStoreBaseTestsTest.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 using Xunit.Abstractions;
 
-using static LaunchDarkly.Sdk.Server.Interfaces.BigSegmentStoreTypes;
+using static LaunchDarkly.Sdk.Server.Subsystems.BigSegmentStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.SharedTests.BigSegmentStore
 {
@@ -32,7 +32,7 @@ namespace LaunchDarkly.Sdk.Server.SharedTests.BigSegmentStore
         {
         }
 
-        private IBigSegmentStoreFactory CreateStoreFactory(string prefix) =>
+        private IComponentConfigurer<IBigSegmentStore> CreateStoreFactory(string prefix) =>
             new MockStoreFactory(GetOrCreateDataSet(prefix));
 
         private Task ClearData(string prefix)
@@ -66,7 +66,7 @@ namespace LaunchDarkly.Sdk.Server.SharedTests.BigSegmentStore
             return _allData[prefix];
         }
 
-        private class MockStoreFactory : IBigSegmentStoreFactory
+        private class MockStoreFactory : IComponentConfigurer<IBigSegmentStore>
         {
             private readonly DataSet _data;
 
@@ -75,7 +75,7 @@ namespace LaunchDarkly.Sdk.Server.SharedTests.BigSegmentStore
                 _data = data;
             }
 
-            public IBigSegmentStore CreateBigSegmentStore(LdClientContext context) =>
+            public IBigSegmentStore Build(LdClientContext context) =>
                 new MockStore(_data);
         }
 

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/DataStore/MockAsyncStore.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/DataStore/MockAsyncStore.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading.Tasks;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 
-using static LaunchDarkly.Sdk.Server.Interfaces.DataStoreTypes;
+using static LaunchDarkly.Sdk.Server.Subsystems.DataStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
 {

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/DataStore/MockDatabase.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/DataStore/MockDatabase.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-using static LaunchDarkly.Sdk.Server.Interfaces.DataStoreTypes;
+using static LaunchDarkly.Sdk.Server.Subsystems.DataStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
 {

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/DataStore/MockSyncStore.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/DataStore/MockSyncStore.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 
-using static LaunchDarkly.Sdk.Server.Interfaces.DataStoreTypes;
+using static LaunchDarkly.Sdk.Server.Subsystems.DataStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
 {

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/DataStore/PersistentDataStoreBaseTestsAsyncTest.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/DataStore/PersistentDataStoreBaseTestsAsyncTest.cs
@@ -1,5 +1,5 @@
 ﻿using System.Threading.Tasks;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,7 +20,7 @@ namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
 
         public PersistentDataStoreBaseTestsAsyncTest(ITestOutputHelper testOutput) : base(testOutput) { }
 
-        private IPersistentDataStoreAsyncFactory CreateStoreFactory(string prefix) =>
+        private IComponentConfigurer<IPersistentDataStoreAsync> CreateStoreFactory(string prefix) =>
             new MockAsyncStoreFactory { Database = MockDatabase.Instance, Prefix = prefix };
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
@@ -28,12 +28,12 @@ namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
             MockDatabase.Instance.Clear(prefix);
 #pragma warning restore CS1998
 
-        private class MockAsyncStoreFactory : IPersistentDataStoreAsyncFactory
+        private class MockAsyncStoreFactory : IComponentConfigurer<IPersistentDataStoreAsync>
         {
             internal MockDatabase Database { get; set; }
             internal string Prefix { get; set; }
 
-            public IPersistentDataStoreAsync CreatePersistentDataStore(LdClientContext context) =>
+            public IPersistentDataStoreAsync Build(LdClientContext context) =>
                 new MockAsyncStore(Database, Prefix);
         }
     }

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/DataStore/PersistentDataStoreBaseTestsSyncTest.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/DataStore/PersistentDataStoreBaseTestsSyncTest.cs
@@ -1,5 +1,5 @@
 ﻿using System.Threading.Tasks;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,7 +20,7 @@ namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
 
         public PersistentDataStoreBaseTestsSyncTest(ITestOutputHelper testOutput) : base(testOutput) { }
 
-        private IPersistentDataStoreFactory CreateStoreFactory(string prefix) =>
+        private IComponentConfigurer<IPersistentDataStore> CreateStoreFactory(string prefix) =>
             new MockSyncStoreFactory { Database = MockDatabase.Instance, Prefix = prefix };
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
@@ -28,12 +28,12 @@ namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
             MockDatabase.Instance.Clear(prefix);
 #pragma warning restore CS1998
 
-        private class MockSyncStoreFactory : IPersistentDataStoreFactory
+        private class MockSyncStoreFactory : IComponentConfigurer<IPersistentDataStore>
         {
             internal MockDatabase Database { get; set; }
             internal string Prefix { get; set; }
 
-            public IPersistentDataStore CreatePersistentDataStore(LdClientContext context) =>
+            public IPersistentDataStore Build(LdClientContext context) =>
                 new MockSyncStore(Database, Prefix);
         }
     }

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/LaunchDarkly.ServerSdk.SharedTests.Tests.csproj
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/LaunchDarkly.ServerSdk.SharedTests.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>LaunchDarkly.Sdk.Server.SharedTests</RootNamespace>
   </PropertyGroup>

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/BigSegmentStore/BigSegmentStoreBaseTests.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/BigSegmentStore/BigSegmentStoreBaseTests.cs
@@ -1,10 +1,10 @@
 ﻿using System.Threading.Tasks;
 using LaunchDarkly.Logging;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 using Xunit;
 using Xunit.Abstractions;
 
-using static LaunchDarkly.Sdk.Server.Interfaces.BigSegmentStoreTypes;
+using static LaunchDarkly.Sdk.Server.Subsystems.BigSegmentStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.SharedTests.BigSegmentStore
 {
@@ -47,9 +47,9 @@ namespace LaunchDarkly.Sdk.Server.SharedTests.BigSegmentStore
 
         private IBigSegmentStore MakeStore()
         {
-            var context = new LdClientContext(new BasicConfiguration("sdk-key", false, _testLogging.Logger("")),
-                LaunchDarkly.Sdk.Server.Configuration.Default("sdk-key"));
-            return Configuration.StoreFactoryFunc(prefix).CreateBigSegmentStore(context);
+            var context = new LdClientContext("sdk-key", null, null,
+                Components.HttpConfiguration().Build(new LdClientContext("sdk-key")), _testLogging.Logger(""), false, null);
+            return Configuration.StoreFactoryFunc(prefix).Build(context);
         }
 
         private async Task<IBigSegmentStore> MakeEmptyStore()

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/BigSegmentStore/BigSegmentStoreTestConfig.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/BigSegmentStore/BigSegmentStoreTestConfig.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 
-using static LaunchDarkly.Sdk.Server.Interfaces.BigSegmentStoreTypes;
+using static LaunchDarkly.Sdk.Server.Subsystems.BigSegmentStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.SharedTests.BigSegmentStore
 {
@@ -18,7 +18,7 @@ namespace LaunchDarkly.Sdk.Server.SharedTests.BigSegmentStore
     /// </remarks>
     /// <param name="prefix">the database prefix</param>
     /// <returns>a configured factory</returns>
-    public delegate IBigSegmentStoreFactory StoreFactoryFunc(string prefix);
+    public delegate IComponentConfigurer<IBigSegmentStore> StoreFactoryFunc(string prefix);
 
     /// <summary>
     /// An asynchronous function that removes all data from the underlying

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/DataStore/DataBuilder.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/DataStore/DataBuilder.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-using static LaunchDarkly.Sdk.Server.Interfaces.DataStoreTypes;
+using static LaunchDarkly.Sdk.Server.Subsystems.DataStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
 {

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/DataStore/FlagTestData.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/DataStore/FlagTestData.cs
@@ -1,12 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using LaunchDarkly.Logging;
-using LaunchDarkly.Sdk.Server.Interfaces;
-using Xunit;
+﻿using System.Collections.Generic;
 
-using static LaunchDarkly.Sdk.Server.Interfaces.DataStoreTypes;
+using static LaunchDarkly.Sdk.Server.Subsystems.DataStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
 {
@@ -20,8 +14,8 @@ namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
 
         public const int GoodVariation1 = 0, GoodVariation2 = 1, BadVariation = 2;
 
-        public static readonly User MainUser = User.WithKey(UserKey),
-            OtherUser = User.WithKey(OtherUserKey);
+        public static readonly Context MainUser = Context.New(UserKey),
+            OtherUser = Context.New(OtherUserKey);
 
         public static ItemDescriptor MakeFlagThatReturnsVariationForSegmentMatch(int version, int variation)
         {

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/DataStore/PersistentDataStoreTestConfig.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/DataStore/PersistentDataStoreTestConfig.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 
 namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
 {
@@ -21,7 +21,7 @@ namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
         /// may be appropriate for the test environment (for instance, pointing it to a database
         /// instance that has been set up for the tests).
         /// </remarks>
-        public Func<string, IPersistentDataStoreFactory> StoreFactoryFunc { get; set; }
+        public Func<string, IComponentConfigurer<IPersistentDataStore>> StoreFactoryFunc { get; set; }
 
         /// <summary>
         /// Set this to a function that takes a prefix string and returns a configured factory for
@@ -34,7 +34,7 @@ namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
         /// may be appropriate for the test environment (for instance, pointing it to a database
         /// instance that has been set up for the tests).
         /// </remarks>
-        public Func<string, IPersistentDataStoreAsyncFactory> StoreAsyncFactoryFunc { get; set; }
+        public Func<string, IComponentConfigurer<IPersistentDataStoreAsync>> StoreAsyncFactoryFunc { get; set; }
         
         /// <summary>
         /// Set this to an asynchronous function that removes all data from the underlying

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/DataStore/TestEntity.cs
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/DataStore/TestEntity.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using static LaunchDarkly.Sdk.Server.Interfaces.DataStoreTypes;
+﻿using static LaunchDarkly.Sdk.Server.Subsystems.DataStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.SharedTests.DataStore
 {

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
@@ -3,7 +3,7 @@
     <Version>2.0.0-alpha.2</Version>
     <PackageId>LaunchDarkly.ServerSdk.SharedTests</PackageId>
     <AssemblyName>LaunchDarkly.ServerSdk.SharedTests</AssemblyName>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <OutputType>Library</OutputType>
     <Description>LaunchDarkly .NET Shared Tests</Description>
     <Company>LaunchDarkly</Company>
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="[6.2.0,7.0.0)" />
-    <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.1,]" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="7.0.0-alpha.3" />
+    <PackageReference Include="LaunchDarkly.Logging" Version="[2.0.0,]" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/src/LaunchDarkly.ServerSdk.Redis/LaunchDarkly.ServerSdk.Redis.csproj
+++ b/src/LaunchDarkly.ServerSdk.Redis/LaunchDarkly.ServerSdk.Redis.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="[6.2.0,7.0.0)" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="7.0.0-alpha.1" />
     <PackageReference Include="StackExchange.Redis" Version="[2.0.513,]" />
   </ItemGroup>
 

--- a/src/LaunchDarkly.ServerSdk.Redis/LaunchDarkly.ServerSdk.Redis.csproj
+++ b/src/LaunchDarkly.ServerSdk.Redis/LaunchDarkly.ServerSdk.Redis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>3.1.0</Version>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <AssemblyName>LaunchDarkly.ServerSdk.Redis</AssemblyName>
     <OutputType>Library</OutputType>
     <PackageId>LaunchDarkly.ServerSdk.Redis</PackageId>

--- a/src/LaunchDarkly.ServerSdk.Redis/Redis.cs
+++ b/src/LaunchDarkly.ServerSdk.Redis/Redis.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Net;
-using LaunchDarkly.Sdk.Server.Interfaces;
 
 namespace LaunchDarkly.Sdk.Server.Integrations
 {
@@ -55,11 +54,11 @@ namespace LaunchDarkly.Sdk.Server.Integrations
         /// </code>
         /// <para>
         /// Note that the builder is passed to one of two methods,
-        /// <see cref="Components.PersistentDataStore(IPersistentDataStoreFactory)"/> or
-        /// <see cref="Components.BigSegments(IBigSegmentStoreFactory)"/>, depending on the context in
+        /// <see cref="Components.PersistentDataStore(Subsystems.IComponentConfigurer{Subsystems.IPersistentDataStore})"/> or
+        /// <see cref="Components.BigSegments(Subsystems.IComponentConfigurer{Subsystems.IBigSegmentStore})"/>, depending on the context in
         /// which it is being used. This is because each of those contexts has its own additional
         /// configuration options that are unrelated to the Redis options. For instance, the
-        /// <see cref="Components.PersistentDataStore(IPersistentDataStoreAsyncFactory)"/> builder
+        /// <see cref="Components.PersistentDataStore(Subsystems.IComponentConfigurer{Subsystems.IPersistentDataStore})"/> builder
         /// has options for caching:
         /// </para>
         /// <code>

--- a/src/LaunchDarkly.ServerSdk.Redis/RedisBigSegmentStoreImpl.cs
+++ b/src/LaunchDarkly.ServerSdk.Redis/RedisBigSegmentStoreImpl.cs
@@ -2,11 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 using LaunchDarkly.Logging;
 using StackExchange.Redis;
 
-using static LaunchDarkly.Sdk.Server.Interfaces.BigSegmentStoreTypes;
+using static LaunchDarkly.Sdk.Server.Subsystems.BigSegmentStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.Integrations
 {

--- a/src/LaunchDarkly.ServerSdk.Redis/RedisDataStoreBuilder.cs
+++ b/src/LaunchDarkly.ServerSdk.Redis/RedisDataStoreBuilder.cs
@@ -225,6 +225,10 @@ namespace LaunchDarkly.Sdk.Server.Integrations
             return this;
         }
 
+        // The Build methods are written as *explicit* interface implementations because this class is
+        // implementing IComponentConfigurer<T> with two different type parameters (since the same
+        // builder can be used to create either a regular persistent data store or a Big Segment store).
+
         /// <inheritdoc/>
         IPersistentDataStore IComponentConfigurer<IPersistentDataStore>.Build(LdClientContext context) =>
             new RedisDataStoreImpl(_redisConfig, _prefix, context.Logger.SubLogger("DataStore.Redis"));

--- a/src/LaunchDarkly.ServerSdk.Redis/RedisDataStoreImpl.cs
+++ b/src/LaunchDarkly.ServerSdk.Redis/RedisDataStoreImpl.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using LaunchDarkly.Logging;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 using StackExchange.Redis;
 
-using static LaunchDarkly.Sdk.Server.Interfaces.DataStoreTypes;
+using static LaunchDarkly.Sdk.Server.Subsystems.DataStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.Integrations
 {

--- a/src/LaunchDarkly.ServerSdk.Redis/RedisStoreImplBase.cs
+++ b/src/LaunchDarkly.ServerSdk.Redis/RedisStoreImplBase.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using LaunchDarkly.Logging;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 using StackExchange.Redis;
 
 namespace LaunchDarkly.Sdk.Server.Integrations

--- a/test/LaunchDarkly.ServerSdk.Redis.Tests/LaunchDarkly.ServerSdk.Redis.Tests.csproj
+++ b/test/LaunchDarkly.ServerSdk.Redis.Tests/LaunchDarkly.ServerSdk.Redis.Tests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>LaunchDarkly.Sdk.Server.Integrations</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/LaunchDarkly.ServerSdk.Redis.Tests/RedisBigSegmentStoreTest.cs
+++ b/test/LaunchDarkly.ServerSdk.Redis.Tests/RedisBigSegmentStoreTest.cs
@@ -26,7 +26,7 @@ namespace LaunchDarkly.Sdk.Server.Integrations
             _redis = ConnectionMultiplexer.Connect("localhost:6379,allowAdmin=true");
         }
 
-        private IBigSegmentStoreFactory MakeStoreFactory(string prefix) =>
+        private IComponentConfigurer<IBigSegmentStore> MakeStoreFactory(string prefix) =>
             Redis.DataStore().Prefix(prefix);
 
         private async Task ClearData(string prefix) =>

--- a/test/LaunchDarkly.ServerSdk.Redis.Tests/RedisBigSegmentStoreTest.cs
+++ b/test/LaunchDarkly.ServerSdk.Redis.Tests/RedisBigSegmentStoreTest.cs
@@ -27,7 +27,7 @@ namespace LaunchDarkly.Sdk.Server.Integrations
         }
 
         private IComponentConfigurer<IBigSegmentStore> MakeStoreFactory(string prefix) =>
-            Redis.DataStore().Prefix(prefix);
+            Redis.BigSegmentStore().Prefix(prefix);
 
         private async Task ClearData(string prefix) =>
             await RedisDataStoreTest.ClearDataWithPrefix(_redis, prefix);

--- a/test/LaunchDarkly.ServerSdk.Redis.Tests/RedisBigSegmentStoreTest.cs
+++ b/test/LaunchDarkly.ServerSdk.Redis.Tests/RedisBigSegmentStoreTest.cs
@@ -1,11 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 using LaunchDarkly.Sdk.Server.SharedTests.BigSegmentStore;
 using StackExchange.Redis;
 using Xunit.Abstractions;
 
-using static LaunchDarkly.Sdk.Server.Interfaces.BigSegmentStoreTypes;
+using static LaunchDarkly.Sdk.Server.Subsystems.BigSegmentStoreTypes;
 
 namespace LaunchDarkly.Sdk.Server.Integrations
 {

--- a/test/LaunchDarkly.ServerSdk.Redis.Tests/RedisDataStoreTest.cs
+++ b/test/LaunchDarkly.ServerSdk.Redis.Tests/RedisDataStoreTest.cs
@@ -61,7 +61,7 @@ namespace LaunchDarkly.Sdk.Server.Integrations
             var logCapture = Logs.Capture();
             var logger = logCapture.Logger("BaseLoggerName"); // in real life, the SDK will provide its own base log name
             var context = new LdClientContext("", null, null, null, logger, false, null);
-            using (((IComponentConfigurer<IPersistentDataStore>)Redis.DataStore().Prefix("my-prefix")).Build(context))
+            using (Redis.DataStore().Prefix("my-prefix").Build(context))
             {
                 Assert.Collection(logCapture.GetMessages(),
                     m =>

--- a/test/LaunchDarkly.ServerSdk.Redis.Tests/RedisDataStoreTest.cs
+++ b/test/LaunchDarkly.ServerSdk.Redis.Tests/RedisDataStoreTest.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using LaunchDarkly.Logging;
-using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.Sdk.Server.Subsystems;
 using LaunchDarkly.Sdk.Server.SharedTests.DataStore;
 using StackExchange.Redis;
 using Xunit;

--- a/test/LaunchDarkly.ServerSdk.Redis.Tests/RedisDataStoreTest.cs
+++ b/test/LaunchDarkly.ServerSdk.Redis.Tests/RedisDataStoreTest.cs
@@ -22,7 +22,7 @@ namespace LaunchDarkly.Sdk.Server.Integrations
 
         public RedisDataStoreTest(ITestOutputHelper testOutput) : base(testOutput) { }
 
-        private IPersistentDataStoreFactory MakeStoreFactory(string prefix)
+        private IComponentConfigurer<IPersistentDataStore> MakeStoreFactory(string prefix)
         {
             return Redis.DataStore().Prefix(prefix);
         }
@@ -60,9 +60,8 @@ namespace LaunchDarkly.Sdk.Server.Integrations
         {
             var logCapture = Logs.Capture();
             var logger = logCapture.Logger("BaseLoggerName"); // in real life, the SDK will provide its own base log name
-            var context = new LdClientContext(new BasicConfiguration("", false, logger),
-                LaunchDarkly.Sdk.Server.Configuration.Default(""));
-            using (Redis.DataStore().Prefix("my-prefix").CreatePersistentDataStore(context))
+            var context = new LdClientContext("", null, null, null, logger, false, null);
+            using (((IComponentConfigurer<IPersistentDataStore>)Redis.DataStore().Prefix("my-prefix")).Build(context))
             {
                 Assert.Collection(logCapture.GetMessages(),
                     m =>


### PR DESCRIPTION
* Some SDK types were moved from `Interfaces` to `Subsystems`
* Some interfaces are now replaced by the generic `IComponentConfigurer<T>`(*)
* Updated target framework compatibility

(* Note: for Redis we have both a `PersistentDataStore` component and a `BigSegmentStore` component. Previously we could use literally the same builder class for both, because there were two different factory interfaces with different method names. I could've solved this by doing _explicit_ interface implementations, but instead I chose to have separate `Redis.DataStore()` and `Redis.BigSegmentStore()` factory methods and have a shared base class for the builder— I think it's arguably clearer that way, and it'll map better onto other languages that don't have the same approach to interfaces as .NET.)